### PR TITLE
Feat configure jenkins url

### DIFF
--- a/deploy/master/docker-compose.yml
+++ b/deploy/master/docker-compose.yml
@@ -10,9 +10,12 @@ services:
     image: modernjenkins/jenkins-master
     ports:
       - "8080:8080"
+    environment:
+      - JENKINS_UI_URL=http://localhost:8080
     volumes:
       - plugins:/usr/share/jenkins/ref/plugins
       - warfile:/usr/share/jenkins/ref/warfile
+      - groovy:/var/jenkins_home/init.groovy.d
 
   # Jenkins plugins' configuration
   plugins:
@@ -20,9 +23,11 @@ services:
     volumes:
       - plugins:/usr/share/jenkins/ref/plugins
       - warfile:/usr/share/jenkins/ref/warfile
+      - groovy:/usr/share/jenkins/ref/init.groovy.d
 
 # Define named volumes. These are what we use to share the data from one
 # container to another, thereby making our jenkins.war and plugins available
 volumes:
   plugins:
   warfile:
+  groovy:

--- a/deploy/master/start.sh
+++ b/deploy/master/start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -el
+
+echo "INFO: (re)Starting Jenkins"
+docker-compose down -v
+docker-compose up -d
+
+echo "INFO: Use the following command to watch the logs: "
+echo "docker-compose logs -f"
+

--- a/images/jenkins-plugins/Dockerfile
+++ b/images/jenkins-plugins/Dockerfile
@@ -11,6 +11,9 @@ LABEL dockerfile_location=https://github.com/technolo-g/modern-jenkins/tree/mast
 # https://raw.githubusercontent.com/technolo-g/modern-jenkins/master/images/jenkins-plugins/files/install-plugins.sh
 ADD files/install-plugins.sh /usr/local/bin/
 
+# Add our groovy init files
+ADD files/init.groovy.d /usr/share/jenkins/ref/init.groovy.d
+
 # Download the Jenkins war
 # JENKINS_URL, JENKINS_ROOT, JENKINS_WAR, and JENKINS_SHA are set in the parent
 RUN mkdir -p ${JENKINS_ROOT}/ref/warfile \
@@ -29,6 +32,7 @@ RUN install-plugins.sh `cat /tmp/plugins-main.txt`
 # Export our war and plugin set as volumes
 VOLUME /usr/share/jenkins/ref/plugins
 VOLUME /usr/share/jenkins/ref/warfile
+VOLUME /usr/share/jenkins/ref/init.groovy.d
 
 # It's easy to get confused when just a volume is being used, so let's just keep
 # the container alive for clarity. This entrypoint will keep the container

--- a/images/jenkins-plugins/files/init.groovy.d/01-cofigure-jenkins-url.groovy
+++ b/images/jenkins-plugins/files/init.groovy.d/01-cofigure-jenkins-url.groovy
@@ -1,0 +1,17 @@
+import jenkins.model.*
+
+// Read the environment variable
+url = System.env.JENKINS_UI_URL
+
+// Get the config from our running instance
+urlConfig = JenkinsLocationConfiguration.get()
+
+// Set the config to be the value of the env var
+urlConfig.setUrl(url)
+
+// Save the configuration
+urlConfig.save()
+
+// Print the results
+println("Jenkins URL Set to " + url)
+


### PR DESCRIPTION
#### What does this PR do?
This change adds an environment variable to the compose file
that sets the URL of the Jenkins instance upon boot. This is
done via the script added to init.groovy.d

It also adds a start script for the master.

#### Why did you take this approach?
To allow us to configure the URL when needed.

#### Contribution checklist

- [x] The branch is named something meaningful
- [x] The branch is rebased off of current master
- [x] There is a single commit (or very few smaller ones) with a [Good commit message](https://github.com/torvalds/subsurface-for-dirk/blob/master/README#L92) that includes the issue if there was one
- [x] You have tested this locally yourself


#### A picture of a cute animal (optional)
<img src="https://68.media.tumblr.com/7b36a31855ed619f91b8fc4416d0cafc/tumblr_inline_o6b4ngEE551sdwbtb_540.png" width="350"/>
